### PR TITLE
Implement Application Metrics and Monitoring (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,122 @@ Expected result:
 
 ---
 
+## Monitoring & Metrics
+This API includes Spring Boot Actuator and Micrometer Prometheus integration to provide health probes, runtime metrics, and business metrics for authentication flows.
+
+### Monitoring Setup
+Dependencies used:
+- `spring-boot-starter-actuator`
+- `micrometer-registry-prometheus`
+
+Main actuator configuration:
+
+```properties
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.roles=ADMIN
+management.endpoint.health.show-details=when-authorized
+management.health.livenessstate.enabled=true
+management.health.readinessstate.enabled=true
+```
+
+### Endpoint Access and Security
+Monitoring endpoints follow least-privilege rules:
+
+| Endpoint | Access | Purpose |
+|---|---|---|
+| `/actuator/health` | Public | General health status for platform checks |
+| `/actuator/health/liveness` | Public | Liveness probe |
+| `/actuator/health/readiness` | Public | Readiness probe |
+| `/actuator/info` | Public (if exposed) | Build/application info |
+| `/actuator/metrics` | ADMIN only | Structured metric names and details |
+| `/actuator/prometheus` | ADMIN only | Prometheus scrape output |
+
+Security notes:
+- Public probe endpoints are intentionally available for container orchestrators and platform health checks.
+- Sensitive metric endpoints are restricted to authenticated users with `ROLE_ADMIN`.
+- Existing API endpoint protections remain unchanged.
+
+### Custom Business Metrics
+Custom metrics are emitted for security-critical flows, including:
+- Login attempts and latency (`auth.login.*`)
+- Token refresh attempts and latency (`auth.refresh.*`, `token.refresh.*`)
+- Account action and deactivation metrics (`user.account.*`)
+
+### Quick Verification Commands
+1. Verify public health endpoint:
+
+```bash
+curl -i http://localhost:8080/actuator/health
+```
+
+2. Verify public liveness/readiness probes:
+
+```bash
+curl -i http://localhost:8080/actuator/health/liveness
+curl -i http://localhost:8080/actuator/health/readiness
+```
+
+3. Verify protected metrics endpoint (requires ADMIN token):
+
+```bash
+curl -i http://localhost:8080/actuator/metrics \
+  -H "Authorization: Bearer YOUR_ADMIN_ACCESS_TOKEN"
+```
+
+4. Verify Prometheus scrape output (requires ADMIN token):
+
+```bash
+curl -i http://localhost:8080/actuator/prometheus \
+  -H "Authorization: Bearer YOUR_ADMIN_ACCESS_TOKEN"
+```
+
+Expected checks:
+- `/actuator/health*` responds successfully for healthy state.
+- `/actuator/metrics` and `/actuator/prometheus` return `401` without token.
+- Prometheus output contains `# HELP` and `# TYPE` lines.
+
+### Example Prometheus Scrape Config
+If Prometheus runs outside the API process, set the scrape target to this service:
+
+```yaml
+scrape_configs:
+  - job_name: secureauthapi
+    metrics_path: /actuator/prometheus
+    scheme: http
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+If your Prometheus setup supports auth headers, include an ADMIN bearer token for this endpoint.
+
+### Degraded and Unhealthy Health States
+Health behavior is also validated when dependencies fail.
+- Integration coverage includes a failing health indicator scenario that verifies the API reports `DOWN` with `503 Service Unavailable` for `/actuator/health`.
+- This confirms probe behavior is reliable for outage detection.
+
+### Troubleshooting Monitoring Misconfigurations
+1. `500` on `/actuator/prometheus` in tests:
+- Ensure Prometheus export is enabled in the active profile.
+- Use:
+
+```properties
+management.prometheus.metrics.export.enabled=true
+```
+
+2. Endpoint not found (`404`):
+- Confirm exposure includes `prometheus` and `metrics`.
+
+3. `401` on `/actuator/metrics` or `/actuator/prometheus`:
+- This is expected without an ADMIN token.
+- Use a valid access token for a user with `ROLE_ADMIN`.
+
+4. Probe details missing in `/actuator/health`:
+- Details are intentionally limited by `management.endpoint.health.show-details=when-authorized`.
+- Authenticate with an authorized role to view component details.
+
+---
+
 ## Getting Started
 ### Prerequisites
 
@@ -407,9 +523,9 @@ curl -X GET http://localhost:8080/api/users/me \
 - [X] Rate limiting for API endpoints
 - [X] Swagger/OpenAPI documentation
 - [X] Comprehensive test suite (unit + integration)
+- [X] Performance monitoring and metrics
 - [ ] Docker containerization
 - [ ] CI/CD pipeline setup
-- [ ] Performance monitoring and metrics
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
 		</dependency>
+		<!-- Actuator -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+		<!-- Prometheus Registry -->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/backend/SecureAuthAPI/security/WebSecurityConfig.java
+++ b/src/main/java/backend/SecureAuthAPI/security/WebSecurityConfig.java
@@ -34,14 +34,22 @@ public class WebSecurityConfig {
             "/api/auth/**",
             "/v3/api-docs/**",
             "/swagger-ui/**",
-            "/swagger-ui.html"
+            "/swagger-ui.html",
+            "/actuator/health",
+            "/actuator/health/**"
+    };
+
+    private static final String[] PROTECTED_ACTUATOR_ENDPOINTS = {
+            "/actuator/metrics",
+            "/actuator/metrics/**",
+            "/actuator/prometheus",
+            "/actuator/prometheus/**"
     };
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                // CSRF protection is disabled because this API uses stateless JWT
-                // authentication
+                // CSRF protection is disabled because this API uses stateless JWT authentication
                 .csrf(AbstractHttpConfigurer::disable)
 
                 // Configure exception handling
@@ -52,6 +60,7 @@ public class WebSecurityConfig {
                 // Configure authorization rules
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                        .requestMatchers(PROTECTED_ACTUATOR_ENDPOINTS).hasRole("ADMIN")
                         .anyRequest().authenticated());
 
         // Apply rate limiting before JWT authentication, then apply JWT before username/password auth

--- a/src/main/java/backend/SecureAuthAPI/service/AuthService.java
+++ b/src/main/java/backend/SecureAuthAPI/service/AuthService.java
@@ -26,6 +26,8 @@ import backend.secureauthapi.model.User;
 import backend.secureauthapi.repository.UserRepository;
 import backend.secureauthapi.security.UserDetailsImpl;
 import backend.secureauthapi.security.jwt.JwtUtils;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -39,8 +41,10 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
     private final UserMapper userMapper;
     private final UserDetailsService userDetailsService;
+    private final MeterRegistry meterRegistry;
 
-    @Value("${security.jwt.expiration-ms}") private Long jwtExpirationMs;
+    @Value("${security.jwt.expiration-ms}")
+    private Long jwtExpirationMs;
 
     @Transactional
     public UserResponse register(RegisterRequest registerRequest) {
@@ -59,49 +63,76 @@ public class AuthService {
     @Transactional
     public LoginResponse login(LoginRequest loginRequest, String deviceInfo, String ipAddress) {
 
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(loginRequest.email(),
-                        loginRequest.password()));
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(loginRequest.email(),
+                            loginRequest.password()));
 
-        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+            SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        String accessToken = jwtUtils.generateAccessToken(userDetails);
+            UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
 
-        User user = userRepository.findByEmail(loginRequest.email())
-                .orElseThrow(() -> new InvalidCredentialsException());
+            String accessToken = jwtUtils.generateAccessToken(userDetails);
 
-        String refreshToken = refreshTokenService.issueRefreshToken(user, deviceInfo, ipAddress);
+            User user = userRepository.findByEmail(loginRequest.email())
+                    .orElseThrow(() -> new InvalidCredentialsException());
 
-        Instant expiresAt = Instant.now().plusMillis(jwtExpirationMs);
+            String refreshToken = refreshTokenService.issueRefreshToken(user, deviceInfo, ipAddress);
 
-        UserResponse userResponse = userMapper.toUserResponse(user);
+            Instant expiresAt = Instant.now().plusMillis(jwtExpirationMs);
 
-        return new LoginResponse(accessToken, refreshToken, expiresAt, userResponse);
+            UserResponse userResponse = userMapper.toUserResponse(user);
+            
+            outcome = "success";
+            return new LoginResponse(accessToken, refreshToken, expiresAt, userResponse);
+        } finally {
+            meterRegistry.counter("auth.login.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("auth.login.duration")
+                    .description("Login request duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95, 0.99)
+                    .register(meterRegistry));
+        }
     }
 
     @Transactional
     public RefreshTokenResponse refreshToken(RefreshTokenRequest refreshTokenRequest) {
 
-        User user = refreshTokenService.getUserFromRefreshToken(refreshTokenRequest.refreshToken());
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        String newRefreshToken =
-                refreshTokenService.rotateAndIssueRefreshToken(refreshTokenRequest.refreshToken());
+        try {
+            User user = refreshTokenService.getUserFromRefreshToken(refreshTokenRequest.refreshToken());
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(user.getEmail());
+            String newRefreshToken = refreshTokenService.rotateAndIssueRefreshToken(refreshTokenRequest.refreshToken());
 
-        String newAccessToken = jwtUtils.generateAccessToken(userDetails);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(user.getEmail());
 
-        Instant expiresAt = Instant.now().plusMillis(jwtExpirationMs);
+            String newAccessToken = jwtUtils.generateAccessToken(userDetails);
 
-        return new RefreshTokenResponse(newAccessToken, newRefreshToken, expiresAt);
+            Instant expiresAt = Instant.now().plusMillis(jwtExpirationMs);
+
+            outcome = "success";
+            return new RefreshTokenResponse(newAccessToken, newRefreshToken, expiresAt);
+        } finally {
+            meterRegistry.counter("auth.refresh.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("auth.refresh.duration")
+                    .description("Refresh token request duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     @Transactional
     public MessageResponse logout(LogoutRequest logoutRequest) {
 
         refreshTokenService.revokeToken(logoutRequest.refreshToken());
+
+        meterRegistry.counter("auth.logout").increment();
 
         return new MessageResponse("Logout successful");
     }

--- a/src/main/java/backend/SecureAuthAPI/service/RefreshTokenService.java
+++ b/src/main/java/backend/SecureAuthAPI/service/RefreshTokenService.java
@@ -14,6 +14,8 @@ import backend.secureauthapi.model.User;
 import backend.secureauthapi.repository.RefreshTokenRepository;
 import backend.secureauthapi.security.util.RefreshTokenGenerator;
 import backend.secureauthapi.security.util.RefreshTokenHasher;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -27,12 +29,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
-    @Value("${security.jwt.refresh-expiration-ms}") private Long refreshTokenDurationMs;
+    @Value("${security.jwt.refresh-expiration-ms}")
+    private Long refreshTokenDurationMs;
 
     private final RefreshTokenRepository repository;
     private final RefreshTokenGenerator generator;
     private final RefreshTokenHasher hasher;
     private final Clock clock;
+    private final MeterRegistry meterRegistry;
 
     /**
      * Issues a new refresh token for the given user and persists its hashed value.
@@ -56,6 +60,8 @@ public class RefreshTokenService {
 
         repository.save(refreshToken);
 
+        meterRegistry.counter("token.refresh.issued").increment();
+
         /*
          * Return the raw token to the client; this is the only time the plain-text
          * value is exposed. The server only persists the hash for security.
@@ -69,13 +75,31 @@ public class RefreshTokenService {
      */
     @Transactional
     public void revokeToken(String rawToken) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "error";
+
         String tokenHash = hasher.hash(rawToken);
 
-        repository.findByTokenHashAndRevokedFalse(tokenHash)
-                .ifPresent(refreshToken -> {
-                    refreshToken.revoke();
-                    repository.save(refreshToken);
-                });
+        try {
+            RefreshToken token = repository.findByTokenHashAndRevokedFalse(tokenHash)
+                    .orElse(null);
+
+            if (token == null) {
+                outcome = "not_found";
+                return;
+            }
+
+            token.revoke();
+            repository.save(token);
+            outcome = "revoked";
+        } finally {
+            meterRegistry.counter("token.refresh.revoke.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("token.refresh.revoke.duration")
+                    .description("Single refresh token revoke duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     /**
@@ -92,6 +116,8 @@ public class RefreshTokenService {
 
         activeTokens.forEach(RefreshToken::revoke);
         repository.saveAll(activeTokens);
+
+        meterRegistry.counter("token.refresh.revoked.bulk").increment(activeTokens.size());
     }
 
     /**
@@ -101,20 +127,33 @@ public class RefreshTokenService {
      */
     @Transactional
     public String rotateAndIssueRefreshToken(String rawToken) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
+
         String tokenHash = hasher.hash(rawToken);
 
-        RefreshToken existingToken = repository.findByTokenHash(tokenHash)
-                .orElseThrow(() -> new InvalidRefreshTokenException("Refresh token not found"));
+        try {
+            RefreshToken existingToken = repository.findByTokenHash(tokenHash)
+                    .orElseThrow(() -> new InvalidRefreshTokenException("Refresh token not found"));
 
-        validateToken(existingToken);
+            validateToken(existingToken);
 
-        existingToken.rotate();
-        repository.save(existingToken);
+            existingToken.rotate();
+            repository.save(existingToken);
 
-        return issueRefreshToken(
-                existingToken.getUser(),
-                existingToken.getDeviceInfo(),
-                existingToken.getIpAddress());
+            outcome = "success";
+            return issueRefreshToken(
+                    existingToken.getUser(),
+                    existingToken.getDeviceInfo(),
+                    existingToken.getIpAddress());
+        } finally {
+            meterRegistry.counter("token.refresh.rotate.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("token.refresh.rotate.duration")
+                    .description("Refresh token rotation duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     /**
@@ -123,14 +162,27 @@ public class RefreshTokenService {
      */
     @Transactional(readOnly = true)
     public User getUserFromRefreshToken(String rawToken) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
+
         String tokenHash = hasher.hash(rawToken);
 
-        RefreshToken token = repository.findByTokenHash(tokenHash)
-                .orElseThrow(() -> new InvalidRefreshTokenException("Refresh token not found"));
+        try {
+            RefreshToken token = repository.findByTokenHash(tokenHash)
+                    .orElseThrow(() -> new InvalidRefreshTokenException("Refresh token not found"));
 
-        validateToken(token);
+            validateToken(token);
 
-        return token.getUser();
+            outcome = "success";
+            return token.getUser();
+        } finally {
+            meterRegistry.counter("token.refresh.lookup.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("token.refresh.lookup.duration")
+                    .description("Refresh token lookup and validation duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     /**

--- a/src/main/java/backend/SecureAuthAPI/service/UserService.java
+++ b/src/main/java/backend/SecureAuthAPI/service/UserService.java
@@ -17,6 +17,8 @@ import backend.secureauthapi.exception.user.UserNotFoundException;
 import backend.secureauthapi.mapper.UserMapper;
 import backend.secureauthapi.model.User;
 import backend.secureauthapi.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -27,6 +29,7 @@ public class UserService {
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenService refreshTokenService;
+    private final MeterRegistry meterRegistry;
 
     /**
      * User methods
@@ -35,52 +38,106 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponse getCurrentUser() {
 
-        User user = getCurrentAuthenticatedUser();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        return userMapper.toUserResponse(user);
+        try {
+            User user = getCurrentAuthenticatedUser();
+
+            outcome = "success";
+            return userMapper.toUserResponse(user);
+        } finally {
+            meterRegistry.counter("user.current.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.current.duration")
+                    .description("Current user lookup duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     @Transactional
     public UserResponse updateProfile(UpdateProfileRequest updateProfileRequest) {
 
-        User user = getCurrentAuthenticatedUser();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        user.setName(updateProfileRequest.name());
+        try {
+            User user = getCurrentAuthenticatedUser();
 
-        User updatedUser = userRepository.save(user);
+            user.setName(updateProfileRequest.name());
 
-        return userMapper.toUserResponse(updatedUser);
+            User updatedUser = userRepository.save(user);
+
+            outcome = "success";
+            return userMapper.toUserResponse(updatedUser);
+        } finally {
+            meterRegistry.counter("user.profile.update.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.profile.update.duration")
+                    .description("Profile update duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     @Transactional
     public MessageResponse changePassword(ChangePasswordRequest changePasswordRequest) {
 
-        User user = getCurrentAuthenticatedUser();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        if (!passwordEncoder.matches(changePasswordRequest.currentPassword(),
-                user.getPasswordHash())) {
-            throw new PasswordChangeException("Current password is incorrect");
+        try {
+            User user = getCurrentAuthenticatedUser();
+
+            if (!passwordEncoder.matches(changePasswordRequest.currentPassword(),
+                    user.getPasswordHash())) {
+                throw new PasswordChangeException("Current password is incorrect");
+            }
+
+            user.setPasswordHash(passwordEncoder.encode(changePasswordRequest.newPassword()));
+            userRepository.save(user);
+
+            refreshTokenService.revokeAllTokensByUser(user.getId());
+
+            outcome = "success";
+            return new MessageResponse("Password changed successfully. Please login again.");
+        } finally {
+            meterRegistry.counter("user.password.change.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.password.change.duration")
+                    .description("Password change duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
         }
-
-        user.setPasswordHash(passwordEncoder.encode(changePasswordRequest.newPassword()));
-        userRepository.save(user);
-
-        refreshTokenService.revokeAllTokensByUser(user.getId());
-
-        return new MessageResponse("Password changed successfully. Please login again.");
     }
 
     @Transactional
     public MessageResponse deactivateAccount() {
 
-        User user = getCurrentAuthenticatedUser();
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        user.setActive(false);
-        userRepository.save(user);
+        try {
+            User user = getCurrentAuthenticatedUser();
 
-        refreshTokenService.revokeAllTokensByUser(user.getId());
+            user.setActive(false);
+            userRepository.save(user);
 
-        return new MessageResponse("Account deactivated successfully");
+            refreshTokenService.revokeAllTokensByUser(user.getId());
+
+            meterRegistry.counter("user.account.deactivated").increment();
+            outcome = "success";
+
+            return new MessageResponse("Account deactivated successfully");
+        } finally {
+            meterRegistry.counter("user.account.deactivate.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.account.deactivate.duration")
+                    .description("Account deactivation duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     private User getCurrentAuthenticatedUser() {
@@ -100,52 +157,111 @@ public class UserService {
     @Transactional(readOnly = true)
     public Page<UserResponse> getAllUsers(Pageable pageable) {
 
-        return userRepository
-                .findAll(pageable)
-                .map(userMapper::toUserResponse);
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
+
+        try {
+            Page<UserResponse> users = userRepository
+                    .findAll(pageable)
+                    .map(userMapper::toUserResponse);
+
+            outcome = "success";
+            return users;
+        } finally {
+            meterRegistry.counter("user.admin.list.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.admin.list.duration")
+                    .description("Admin user list retrieval duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     @Transactional(readOnly = true)
     public UserResponse getUserById(Long id) {
 
-        return userRepository.findById(id)
-                .map(userMapper::toUserResponse)
-                .orElseThrow(() -> new UserNotFoundException());
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
+
+        try {
+            UserResponse user = userRepository.findById(id)
+                    .map(userMapper::toUserResponse)
+                    .orElseThrow(() -> new UserNotFoundException());
+
+            outcome = "success";
+            return user;
+        } finally {
+            meterRegistry.counter("user.admin.detail.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.admin.detail.duration")
+                    .description("Admin user detail retrieval duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     @Transactional
     public UserResponse updateUserRole(Long id, UpdateUserRoleRequest request) {
 
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new UserNotFoundException());
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        user.setRole(request.role());
-        User updatedUser = userRepository.save(user);
+        try {
+            User user = userRepository.findById(id)
+                    .orElseThrow(() -> new UserNotFoundException());
 
-        // Revoke all active sessions and force user to login again
-        refreshTokenService.revokeAllTokensByUser(id);
+            user.setRole(request.role());
+            User updatedUser = userRepository.save(user);
 
-        return userMapper.toUserResponse(updatedUser);
+            // Revoke all active sessions and force user to login again
+            refreshTokenService.revokeAllTokensByUser(id);
+
+            outcome = "success";
+            return userMapper.toUserResponse(updatedUser);
+        } finally {
+            meterRegistry.counter("user.admin.role.update.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.admin.role.update.duration")
+                    .description("Admin user role update duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
+        }
     }
 
     @Transactional
     public MessageResponse updateUserStatus(Long id, UpdateUserStatusRequest request) {
 
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new UserNotFoundException());
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
 
-        user.setActive(request.active());
-        userRepository.save(user);
+        try {
+            User user = userRepository.findById(id)
+                    .orElseThrow(() -> new UserNotFoundException());
 
-        // If deactivating, revoke all active sessions
-        if (!request.active()) {
-            refreshTokenService.revokeAllTokensByUser(id);
+            user.setActive(request.active());
+            userRepository.save(user);
+
+            // If deactivating, revoke all active sessions
+            if (!request.active()) {
+                refreshTokenService.revokeAllTokensByUser(id);
+                meterRegistry.counter("user.account.deactivated.by.admin").increment();
+            } else {
+                meterRegistry.counter("user.account.activated.by.admin").increment();
+            }
+
+            String message = request.active()
+                    ? "User account activated successfully"
+                    : "User account deactivated successfully";
+
+            outcome = "success";
+            return new MessageResponse(message);
+        } finally {
+            meterRegistry.counter("user.admin.status.update.attempts", "outcome", outcome).increment();
+            sample.stop(Timer.builder("user.admin.status.update.duration")
+                    .description("Admin user status update duration")
+                    .tag("outcome", outcome)
+                    .publishPercentiles(0.5, 0.95)
+                    .register(meterRegistry));
         }
-
-        String message = request.active()
-                ? "User account activated successfully"
-                : "User account deactivated successfully";
-
-        return new MessageResponse(message);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,13 @@ security.jwt.refresh-expiration-ms=${JWT_REFRESH_EXPIRATION_MS}
 # Rate Limiting Configuration
 rate-limit.auth.requests-per-minute=${RATE_LIMIT_AUTH_REQUESTS_PER_MINUTE:10}
 rate-limit.api.requests-per-minute=${RATE_LIMIT_API_REQUESTS_PER_MINUTE:60}
+
+# Monitoring & Metrics Configuration
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.roles=ADMIN
+management.endpoint.health.show-details=when-authorized
+
+# Actuator Health Check Configuration
+management.health.livenessstate.enabled=true
+management.health.readinessstate.enabled=true

--- a/src/test/java/backend/SecureAuthAPI/integration/MonitoringDegradedHealthIntegrationTest.java
+++ b/src/test/java/backend/SecureAuthAPI/integration/MonitoringDegradedHealthIntegrationTest.java
@@ -1,0 +1,37 @@
+package backend.SecureAuthAPI.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@DisplayName("Monitoring Degraded Health Integration Tests")
+@Import(MonitoringDegradedHealthIntegrationTest.FailingDependencyConfig.class)
+class MonitoringDegradedHealthIntegrationTest extends BaseIntegrationTest {
+
+    @Test
+    @DisplayName("Should report DOWN and 503 when a dependency health indicator fails")
+    void actuatorHealth_whenDependencyFails_reportsDown() throws Exception {
+
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.status").value("DOWN"));
+    }
+
+    @TestConfiguration
+    static class FailingDependencyConfig {
+
+        @Bean(name = "fakeDependency")
+        HealthIndicator fakeDependencyHealthIndicator() {
+            return () -> Health.down()
+                    .withDetail("reason", "simulated dependency failure")
+                    .build();
+        }
+    }
+}

--- a/src/test/java/backend/SecureAuthAPI/integration/MonitoringIntegrationTest.java
+++ b/src/test/java/backend/SecureAuthAPI/integration/MonitoringIntegrationTest.java
@@ -1,0 +1,251 @@
+package backend.SecureAuthAPI.integration;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+import backend.secureauthapi.dto.request.LoginRequest;
+import backend.secureauthapi.dto.request.RefreshTokenRequest;
+import backend.secureauthapi.model.Role;
+import backend.secureauthapi.model.User;
+import backend.secureauthapi.repository.UserRepository;
+
+@DisplayName("Monitoring Integration Tests")
+class MonitoringIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private static final String VALID_PASSWORD = "SecurePass123!";
+
+    @Nested
+    @DisplayName("Health Probe Endpoints")
+    class ProbeEndpointTests {
+
+        @Test
+        @DisplayName("Should return 200 for /actuator/health without authentication")
+        void actuatorHealth_withoutToken_returns200() throws Exception {
+
+            mockMvc.perform(get("/actuator/health"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").isString());
+        }
+
+        @Test
+        @DisplayName("Should return 200 for /actuator/health/liveness without authentication")
+        void actuatorHealthLiveness_withoutToken_returns200() throws Exception {
+
+            mockMvc.perform(get("/actuator/health/liveness"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").isString());
+        }
+
+        @Test
+        @DisplayName("Should return 200 for /actuator/health/readiness without authentication")
+        void actuatorHealthReadiness_withoutToken_returns200() throws Exception {
+
+            mockMvc.perform(get("/actuator/health/readiness"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").isString());
+        }
+    }
+
+    @Nested
+    @DisplayName("Actuator Security")
+    class ActuatorSecurityTests {
+
+        @Test
+        @DisplayName("Should return 401 for /actuator/metrics without authentication")
+        void actuatorMetrics_withoutToken_returns401() throws Exception {
+
+            mockMvc.perform(get("/actuator/metrics"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("Should return 401 for /actuator/prometheus without authentication")
+        void actuatorPrometheus_withoutToken_returns401() throws Exception {
+
+            mockMvc.perform(get("/actuator/prometheus"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("Should return 200 for /actuator/metrics with ADMIN token")
+        void actuatorMetrics_withAdminToken_returns200() throws Exception {
+
+            String adminEmail = uniqueEmail("admin-metrics");
+            saveUser("Admin Metrics", adminEmail, VALID_PASSWORD, Role.ADMIN);
+            String adminAccessToken = loginAndGetAccessToken(adminEmail, VALID_PASSWORD);
+
+            mockMvc.perform(get("/actuator/metrics")
+                    .header("Authorization", "Bearer " + adminAccessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(
+                            MediaType.parseMediaType("application/vnd.spring-boot.actuator.v3+json")))
+                    .andExpect(jsonPath("$.names").isArray())
+                    .andExpect(jsonPath("$.names", hasItem("auth.login.attempts")));
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("Should return 200 and valid exposition format for /actuator/prometheus with ADMIN token")
+        void actuatorPrometheus_withAdminToken_returns200AndOpenMetricsText() throws Exception {
+
+            String adminEmail = uniqueEmail("admin-prometheus");
+            saveUser("Admin Prom", adminEmail, VALID_PASSWORD, Role.ADMIN);
+            String adminAccessToken = loginAndGetAccessToken(adminEmail, VALID_PASSWORD);
+
+            mockMvc.perform(get("/actuator/prometheus")
+                    .header("Authorization", "Bearer " + adminAccessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                    .andExpect(content().string(containsString("# HELP")))
+                    .andExpect(content().string(containsString("# TYPE")));
+        }
+    }
+
+    @Nested
+    @DisplayName("Custom Metric Presence")
+    class CustomMetricPresenceTests {
+
+        @Test
+        @Transactional
+        @DisplayName("Should expose login metrics after one failure and one success")
+        void prometheus_afterLogin_containsAuthLoginMetrics() throws Exception {
+
+            String userEmail = uniqueEmail("user-login-metrics");
+            saveUser("User Login", userEmail, VALID_PASSWORD, Role.USER);
+
+            LoginRequest failedLogin = new LoginRequest(userEmail, "WrongPassword999!");
+            mockMvc.perform(post("/api/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(failedLogin)))
+                    .andExpect(status().isUnauthorized());
+
+            LoginRequest successfulLogin = new LoginRequest(userEmail, VALID_PASSWORD);
+            mockMvc.perform(post("/api/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(successfulLogin)))
+                    .andExpect(status().isOk());
+
+            String adminToken = createAdminAndGetToken("admin-check-login");
+
+            mockMvc.perform(get("/actuator/prometheus")
+                    .header("Authorization", "Bearer " + adminToken))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("auth_login_attempts_total")))
+                    .andExpect(content().string(containsString("outcome=\"success\"")))
+                    .andExpect(content().string(containsString("outcome=\"failure\"")))
+                    .andExpect(content().string(containsString("auth_login_duration_seconds")));
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("Should expose refresh metrics after token refresh flow")
+        void prometheus_afterRefresh_containsAuthRefreshMetrics() throws Exception {
+
+            String userEmail = uniqueEmail("user-refresh-metrics");
+            saveUser("User Refresh", userEmail, VALID_PASSWORD, Role.USER);
+
+            String refreshToken = loginAndGetRefreshToken(userEmail, VALID_PASSWORD);
+            RefreshTokenRequest refreshRequest = new RefreshTokenRequest(refreshToken);
+
+            mockMvc.perform(post("/api/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(refreshRequest)))
+                    .andExpect(status().isOk());
+
+            String adminToken = createAdminAndGetToken("admin-check-refresh");
+
+            mockMvc.perform(get("/actuator/prometheus")
+                    .header("Authorization", "Bearer " + adminToken))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("auth_refresh_attempts_total")))
+                    .andExpect(content().string(containsString("auth_refresh_duration_seconds")));
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("Should expose account action metrics after account deactivation")
+        void prometheus_afterDeactivate_containsAccountActionMetric() throws Exception {
+
+            String userEmail = uniqueEmail("user-deactivate-metrics");
+            saveUser("User Deactivate", userEmail, VALID_PASSWORD, Role.USER);
+            String userAccessToken = loginAndGetAccessToken(userEmail, VALID_PASSWORD);
+
+            mockMvc.perform(delete("/api/users/me")
+                    .header("Authorization", "Bearer " + userAccessToken)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+
+            String adminToken = createAdminAndGetToken("admin-check-deactivate");
+
+            mockMvc.perform(get("/actuator/prometheus")
+                    .header("Authorization", "Bearer " + adminToken))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("user_account_deactivate_attempts_total")))
+                    .andExpect(content().string(containsString("outcome=\"success\"")));
+        }
+    }
+
+    // Helpers
+    private User saveUser(String name, String email, String rawPassword, Role role) {
+        User user = new User(name, email, passwordEncoder.encode(rawPassword), role);
+        return userRepository.save(user);
+    }
+
+    private String loginAndGetAccessToken(String email, String password) throws Exception {
+        LoginRequest loginRequest = new LoginRequest(email, password);
+
+        String loginResponse = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return JsonPath.read(loginResponse, "$.accessToken");
+    }
+
+    private String loginAndGetRefreshToken(String email, String password) throws Exception {
+        LoginRequest loginRequest = new LoginRequest(email, password);
+
+        String loginResponse = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return JsonPath.read(loginResponse, "$.refreshToken");
+    }
+
+    private String createAdminAndGetToken(String emailPrefix) throws Exception {
+        String adminEmail = uniqueEmail(emailPrefix);
+        saveUser("Monitoring Admin", adminEmail, VALID_PASSWORD, Role.ADMIN);
+        return loginAndGetAccessToken(adminEmail, VALID_PASSWORD);
+    }
+
+    private String uniqueEmail(String prefix) {
+        return prefix + "." + System.nanoTime() + "@test.com";
+    }
+}

--- a/src/test/java/backend/SecureAuthAPI/service/AuthServiceTest.java
+++ b/src/test/java/backend/SecureAuthAPI/service/AuthServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -21,6 +20,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import backend.secureauthapi.dto.request.LoginRequest;
 import backend.secureauthapi.dto.request.LogoutRequest;
 import backend.secureauthapi.dto.request.RefreshTokenRequest;
@@ -59,18 +59,29 @@ class AuthServiceTest {
 
     @Mock
     private RefreshTokenService refreshTokenService;
-    
+
     @Mock
     private UserMapper userMapper;
-    
+
     @Mock
     private UserDetailsService userDetailsService;
 
-    @InjectMocks
     private AuthService authService;
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @BeforeEach
     void setUp() {
+        authService = new AuthService(
+                userRepository,
+                passwordEncoder,
+                authenticationManager,
+                jwtUtils,
+                refreshTokenService,
+                userMapper,
+                userDetailsService,
+                meterRegistry);
+
         ReflectionTestUtils.setField(authService, "jwtExpirationMs", 3600000L);
     }
 

--- a/src/test/java/backend/SecureAuthAPI/service/RefreshTokenServiceTest.java
+++ b/src/test/java/backend/SecureAuthAPI/service/RefreshTokenServiceTest.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import backend.secureauthapi.exception.token.InvalidRefreshTokenException;
 import backend.secureauthapi.exception.token.RefreshTokenReuseException;
 import backend.secureauthapi.model.RefreshToken;
@@ -45,15 +45,23 @@ class RefreshTokenServiceTest {
 
     @Mock
     private RefreshTokenHasher hasher;
-    
+
     @Mock
     private Clock clock;
 
-    @InjectMocks
     private RefreshTokenService refreshTokenService;
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @BeforeEach
     void setUp() {
+
+        refreshTokenService = new RefreshTokenService(
+                repository,
+                generator,
+                hasher,
+                clock,
+                meterRegistry);
 
         ReflectionTestUtils.setField(refreshTokenService, "refreshTokenDurationMs", 604800000L);
     }

--- a/src/test/java/backend/SecureAuthAPI/service/UserServiceTest.java
+++ b/src/test/java/backend/SecureAuthAPI/service/UserServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -27,6 +26,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import backend.secureauthapi.dto.request.ChangePasswordRequest;
 import backend.secureauthapi.dto.request.UpdateProfileRequest;
 import backend.secureauthapi.dto.request.UpdateUserRoleRequest;
@@ -53,15 +53,23 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
-    
+
     @Mock
     private RefreshTokenService refreshTokenService;
 
-    @InjectMocks
     private UserService userService;
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @BeforeEach
     void setUp() {
+
+        userService = new UserService(
+                userRepository,
+                userMapper,
+                passwordEncoder,
+                refreshTokenService,
+                meterRegistry);
 
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken("john@example.com",
                 null);

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -7,3 +7,8 @@ spring.jpa.properties.hibernate.format_sql=true
 security.jwt.secret=9pBvh3ssrPnngoRZ0dHdBb390cwJLn/NQw1obuBh5gE=
 security.jwt.expiration-ms=900000
 security.jwt.refresh-expiration-ms=604800000
+
+# Monitoring & Metrics Configuration
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.probes.enabled=true
+management.prometheus.metrics.export.enabled=true


### PR DESCRIPTION
## Description
Implements Issue #14 (Application Metrics and Monitoring) by integrating Actuator + Micrometer Prometheus, securing monitoring endpoints, adding business metrics instrumentation, validating monitoring behavior with integration tests, and documenting operational usage.

Closes #14

## Changes Made
### Monitoring implementation:
- Added Spring Boot Actuator and Micrometer Prometheus registry dependencies
- Enabled actuator exposure for `health`, `info`, `metrics`, and `prometheus`
- Enabled probe-friendly health endpoints (`/actuator/health/liveness`, `/actuator/health/readiness`)
- Configured monitoring properties in application profiles for local and test validation

### Security integration:
- Kept health probe endpoints publicly accessible for platform checks
- Restricted `/actuator/metrics` and `/actuator/prometheus` to `ROLE_ADMIN`
- Preserved existing authentication and authorization behavior for API endpoints

### Custom business metrics:
- Added counters and timers for authentication flows (login, refresh, logout)
- Added token lifecycle metrics in refresh-token operations
- Added user/account action metrics (including account deactivation and admin account actions)
- Applied consistent naming and outcome tags across metric families

### Integration tests:
- Added/updated `MonitoringIntegrationTest` coverage for:
	- health probe endpoint availability (`/health`, `/health/liveness`, `/health/readiness`)
	- actuator endpoint authorization rules (`401` without token, access with ADMIN token)
	- Prometheus exposition format validation
	- selected custom metric presence after auth and account flows
- Added `MonitoringDegradedHealthIntegrationTest` to validate degraded/unhealthy behavior when a dependency health indicator fails (`DOWN` and `503`)

### Documentation:
- Updated README with:
	- monitoring setup and required dependencies
	- endpoint list and security notes (public probes vs protected metrics endpoints)
	- Prometheus scrape configuration example
	- quick verification commands for health, metrics, and Prometheus endpoints
	- troubleshooting guidance for common monitoring misconfigurations

## What is validated
- Actuator endpoints are enabled with least-privilege exposure
- Liveness and readiness probes are functional and documented
- Custom business metrics are emitted and visible through actuator metrics
- Prometheus endpoint returns valid scrape output
- Monitoring endpoints are secured according to defined access rules
- Degraded/unhealthy health behavior is validated through integration testing
- Documentation includes setup, verification commands, scrape example, and troubleshooting notes

## **Acceptance Criteria:**
- [X] Actuator endpoints are enabled with least-privilege exposure
- [X] Liveness and readiness probes are functional and documented
- [X] Custom business metrics are emitted and visible in `/actuator/metrics`
- [X] Prometheus endpoint is available and returns valid scrape output
- [X] Monitoring endpoints are secured according to defined access rules
- [X] No regression in authentication/authorization behavior after changes
- [X] Documentation includes setup, verification, and troubleshooting guidance